### PR TITLE
chore: use baby jubjub curve definition from stdlib

### DIFF
--- a/remask/src/lib.nr
+++ b/remask/src/lib.nr
@@ -1,13 +1,6 @@
 use dep::std::ec::tecurve::affine::Curve as AffineCurve;
 use dep::std::ec::tecurve::affine::Point as Gaffine;
-
-global bjj_a = 168700;
-global bjj_d = 168696;
-global bjj_generator_x = 995203441582195749578291179787384436505546430278305826713579947235728471134;
-global bjj_generator_y = 5472060717959818805561601436314318772137091100104008585924551046643952123905;
-global bjj_basept_x    = 5299619240641551281634865583518297030282874472190772894086521144482721001553;
-global bjj_basept_y    = 16950150798460657717958625567821834550301663161624707787222815936182638968203;
-global bjj_l = 2736030358979909402780800718157159386076813972158567259200215660948447373041; // order of the big prime subgroup of the curve = order of basept
+use dep::std::ec::consts::te::baby_jubjub;
 
 /// Exponential ElGamal re-Encryption on Baby Jubjub,
 /// input is the resulting ciphertext of an ElGamal encryption, i.e a tuple of two points on the Baby Jubjub curve
@@ -17,9 +10,9 @@ global bjj_l = 27360303589799094027808007181571593860768139721585672592002156609
 /// The public_key point passed as an argument must correspond to a valid public key, i.e an element of the Baby Jubjub curve
 pub fn exp_elgamal_remask(
     public_key: Gaffine,
-    input: (Gaffine,Gaffine),
+    input: (Gaffine, Gaffine),
     randomness: Field
-) -> (Gaffine,Gaffine) {
+) -> (Gaffine, Gaffine) {
     assert(is_valid_subgroup(public_key)); // checks the public key is valid
     let bjj_affine = get_affine_curve();
     let base_pt = get_base_point();
@@ -29,18 +22,19 @@ pub fn exp_elgamal_remask(
 }
 
 fn get_affine_curve() -> AffineCurve {
-    AffineCurve::new(bjj_a, bjj_d, Gaffine::new(bjj_generator_x, bjj_generator_y))
+    baby_jubjub().curve
 }
 
 fn get_base_point() -> Gaffine {
-    Gaffine::new(bjj_basept_x, bjj_basept_y)
+    baby_jubjub().base8
 }
 
 /// This function checks that a point is in the big prime subgroup of the Baby Jubjub curve. 
 /// It is used to check that a public key is valid.
-fn is_valid_subgroup(point: Gaffine) -> bool {
+pub fn is_valid_subgroup(point: Gaffine) -> bool {
     let bjj_affine = get_affine_curve();
+    let bjj_suborder = baby_jubjub().suborder;
     let is_on_curve = bjj_affine.contains(point); // checks the point is on bjj
-    let is_in_big_prime_subgroup = bjj_affine.mul(bjj_l, point).is_zero(); // checks the point is in the big prime subgroup of bjj
+    let is_in_big_prime_subgroup = bjj_affine.mul(bjj_suborder, point).is_zero(); // checks the point is in the big prime subgroup of bjj
     is_on_curve & is_in_big_prime_subgroup
 }

--- a/shuffle_encrypt/src/main.nr
+++ b/shuffle_encrypt/src/main.nr
@@ -8,14 +8,14 @@ global N: Field = 6;
 
 pub fn main(
     apk: pub Gaffine,
-    preshuffle: pub [(Gaffine,Gaffine); N],
-    postshuffle: pub [(Gaffine,Gaffine); N],
+    preshuffle: pub [(Gaffine, Gaffine); N],
+    postshuffle: pub [(Gaffine, Gaffine); N],
     shuffle: [Field; N],
-    rand: [Field; N],
+    rand: [Field; N]
 ) {
     assert_valid_permutation(shuffle);
     assert(is_valid_subgroup(apk));
-    
+
     for i in 0..N {
         let result = exp_elgamal_remask(apk, preshuffle[shuffle[i]], rand[i]);
         assert_points_equal(result.0, postshuffle[i].0);


### PR DESCRIPTION
This PR updates `remask` to use the definition of the baby jubjub curve from the noir stdlib to remove the need for defining hardcoded constants for it here.

We could remove the two helper functions for getting the curve + base point and just read directly from the `baby_jubjub()` return value but I'll leave whether that's desirable up to you.